### PR TITLE
fix next-server-side-rendering-demo

### DIFF
--- a/advanced-atjs-integration-serverstate/package.json
+++ b/advanced-atjs-integration-serverstate/package.json
@@ -26,7 +26,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   }

--- a/ecid-analytics-atjs-integration/package.json
+++ b/ecid-analytics-atjs-integration/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   }

--- a/ecid-analytics-integration/package.json
+++ b/ecid-analytics-integration/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   }

--- a/ecid-customer-ids-integration/package.json
+++ b/ecid-customer-ids-integration/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   }

--- a/ecid-integration/package.json
+++ b/ecid-integration/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   }

--- a/feature-flag/package.json
+++ b/feature-flag/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "alpha",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
     "handlebars": "^4.7.4",

--- a/multiple-mbox-ecid-analytics-atjs-integration/package.json
+++ b/multiple-mbox-ecid-analytics-atjs-integration/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   }

--- a/next-server-side-rendering-demo/helpers/target-server-side.js
+++ b/next-server-side-rendering-demo/helpers/target-server-side.js
@@ -26,14 +26,21 @@ function getTargetOptions(ctx) {
   };
 }
 
-function setTraceToken(trace = {}, ctx) {
+function setTraceToken(request = {}, ctx) {
+  const { trace={} } = request;
   const { authorizationToken = ctx.query.authorization } = trace;
 
   if (!authorizationToken || typeof authorizationToken !== "string") {
-    return trace;
+    return request;
   }
 
-  return Object.assign({}, trace, { authorizationToken });
+  return {
+    ...request,
+    trace: {
+      ...trace,
+      authorizationToken
+    }
+  }
 }
 
 function setResponseCookies(ctx, response) {
@@ -47,12 +54,13 @@ async function prefetchOffers(ctx) {
     return {};
   }
   const requestURL = ctx.req.headers.host + ctx.asPath;
-  const prefetchViewsRequest = {
+  let prefetchViewsRequest = {
     prefetch: {
       views: [{ address: { url: requestURL } }]
     }
   };
-  prefetchViewsRequest.trace = setTraceToken(prefetchViewsRequest.trace, ctx);
+
+  prefetchViewsRequest = setTraceToken(prefetchViewsRequest, ctx);
 
   const options = Object.assign(
     { request: prefetchViewsRequest },

--- a/next-server-side-rendering-demo/package.json
+++ b/next-server-side-rendering-demo/package.json
@@ -20,7 +20,7 @@
     "@adobe/target-nodejs-sdk": false
   },
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.0.0",
     "nookies": "^2.0.8",

--- a/on-device-decisioning/package.json
+++ b/on-device-decisioning/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "alpha",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
     "handlebars": "^4.7.4",

--- a/react-shopping-cart-demo/package.json
+++ b/react-shopping-cart-demo/package.json
@@ -15,7 +15,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "axios": "^0.19.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.16.4",

--- a/shared-ecid-analytics-integration/package.json
+++ b/shared-ecid-analytics-integration/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1",
     "uuid": "^3.3.3"

--- a/target-only/package.json
+++ b/target-only/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   },

--- a/target-traces/package.json
+++ b/target-traces/package.json
@@ -25,7 +25,7 @@
   "author": "Adobe Systems Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/target-nodejs-sdk": "^1.0.3",
+    "@adobe/target-nodejs-sdk": "^2.1.0",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1"
   }


### PR DESCRIPTION
## Description

This fix prevents an empty `trace` object from being sent with a delivery request.  

## Related Issue

https://github.com/adobe/target-nodejs-sdk-samples/issues/17

## How Has This Been Tested?

Manually


